### PR TITLE
[Security] Upgrade to latest XML-Crypto 6.1 and use signed data correctly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ workflows:
       - test:
           matrix:
             parameters:
-              node-version: ["10", "12", "14", "16", "18", "latest"]
+              node-version: ["10", "12", "14", "16", "18", "20", "latest"]
       - publish:
           requires:
             - build

--- a/.github/workflows/notify-ci-status.yml
+++ b/.github/workflows/notify-ci-status.yml
@@ -1,12 +1,17 @@
 name: Notify CI status
 
-on: status
+on:
+  check_suite:
+    types: [completed]
+  status:
 
 jobs:
   call-workflow:
     if: >-
-      github.event.branches[0].name == 'master' &&
-      (github.event.state == 'error' || github.event.state == 'failure')    
+      (github.event.branches[0].name == github.event.repository.default_branch &&
+        (github.event.state == 'error' || github.event.state == 'failure')) ||
+      (github.event.check_suite.head_branch == github.event.repository.default_branch &&
+        github.event.check_suite.conclusion != 'success')
     uses: Clever/ci-scripts/.github/workflows/reusable-notify-ci-status.yml@master
     secrets:
       CIRCLE_CI_INTEGRATIONS_URL: ${{ secrets.CIRCLE_CI_INTEGRATIONS_URL }}

--- a/lib/saml2.coffee
+++ b/lib/saml2.coffee
@@ -6,7 +6,6 @@ url           = require 'url'
 util          = require 'util'
 xmlbuilder    = require 'xmlbuilder2'
 xmlcrypto     = require 'xml-crypto'
-SignedXmlPatch     = require('xml-crypto-patch').SignedXml;
 xmldom        = require '@xmldom/xmldom'
 xmlenc        = require 'xml-encryption'
 zlib          = require 'zlib'
@@ -246,7 +245,7 @@ check_saml_signature = (xml, certificate) ->
   # Call documentElement to explicitly start from the root element of the document.
   signature = xmlcrypto.xpath(doc.documentElement, "./*[local-name(.)='Signature' and namespace-uri(.)='http://www.w3.org/2000/09/xmldsig#']")
   return null unless signature.length is 1
-  sig = new SignedXmlPatch(
+  sig = new SignedXml(
     {
       publicCert: format_pem(certificate, 'CERTIFICATE')
     }
@@ -271,27 +270,7 @@ check_saml_signature = (xml, certificate) ->
 # elements for security reasons.
 # deprecate
 get_signed_data = (doc, sig) ->
-  return sig.signedReferences; # use new API
-  _.map sig.references, (ref) ->
-    uri = ref.uri
-    if not uri?
-      uri = ''
-    if uri[0] is '#'
-      uri = uri.substring(1)
-
-    elem = []
-    if uri is ""
-      elem = xmlcrypto.xpath(doc, "//*")
-    else
-      for idAttribute in ["Id", "ID"]
-        elem = xmlcrypto.xpath(doc, "//*[@*[local-name(.)='" + idAttribute + "']='" + uri + "']")
-        if elem.length > 0
-          break
-
-    unless elem.length > 0
-      throw new Error("Invalid signature; must be a reference to '#{ref.uri}'")
-    sig.getCanonXml ref.transforms, elem[0], { inclusiveNamespacesPrefixList: ref.inclusiveNamespacesPrefixList }
-
+  return sig.getSignedReferences(); # use new API
 # Takes in an xml @dom of an object containing a SAML Response and returns an object containing the Destination and
 # InResponseTo attributes of the Response if present. It will throw an error if the Response is missing or does not
 # appear to be valid.

--- a/lib/saml2.coffee
+++ b/lib/saml2.coffee
@@ -57,9 +57,11 @@ sign_authn_request = (xml, private_key, options) ->
     transforms: ['http://www.w3.org/2000/09/xmldsig#enveloped-signature', 'http://www.w3.org/2001/10/xml-exc-c14n#']
     digestAlgorithm: "http://www.w3.org/2001/04/xmlenc#sha256"
   })
-  signer.signingKey = private_key
-  signer.computeSignature xml
+  signer.privateKey = private_key
   signer.canonicalizationAlgorithm = 'http://www.w3.org/2001/10/xml-exc-c14n#';
+  signer.signatureAlgorithm = options?.signatureAlgorithm || 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256'
+
+  signer.computeSignature xml
 
 
   return signer.getSignedXml()

--- a/lib/saml2.coffee
+++ b/lib/saml2.coffee
@@ -259,6 +259,8 @@ check_saml_signature = (xml, certificate) ->
 get_signed_data = (doc, sig) ->
   _.map sig.references, (ref) ->
     uri = ref.uri
+    if not uri?
+      uri = ''
     if uri[0] is '#'
       uri = uri.substring(1)
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "underscore": "^1.8.0",
     "xml-crypto": "^6.1.2",
     "xml-encryption": "^3.0.2",
-    "xmlbuilder2": "^2.4.0"
+    "xmlbuilder2": "^2.4.0",
+    "xpath": "^0.0.34"
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,8 +35,7 @@
     "async": "^3.2.0",
     "debug": "^4.3.0",
     "underscore": "^1.8.0",
-    "xml-crypto": "^3.2.1",
-    "xml-crypto-patch": "securesaml/xml-crypto#v6-minor",
+    "xml-crypto": "^6.1.2",
     "xml-encryption": "^3.0.2",
     "xmlbuilder2": "^2.4.0"
   }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "debug": "^4.3.0",
     "underscore": "^1.8.0",
     "xml-crypto": "^3.2.1",
+    "xml-crypto-patch": "securesaml/xml-crypto#v6-minor",
     "xml-encryption": "^3.0.2",
     "xmlbuilder2": "^2.4.0"
   }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "async": "^3.2.0",
     "debug": "^4.3.0",
     "underscore": "^1.8.0",
-    "xml-crypto": "^3.0.1",
+    "xml-crypto": "^3.2.1",
     "xml-encryption": "^3.0.2",
     "xmlbuilder2": "^2.4.0"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saml2-js",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "SAML 2.0 node helpers",
   "author": "Clever",
   "license": "Apache-2.0",

--- a/test/data/good_assertion_commented_out_digest.xml
+++ b/test/data/good_assertion_commented_out_digest.xml
@@ -1,0 +1,56 @@
+<Assertion xmlns="urn:oasis:names:tc:SAML:2.0:assertion" ID="_3" IssueInstant="2014-03-12T21:35:05.392Z" Version="2.0">
+  <Issuer>http://idp.example.com/metadata.xml</Issuer>
+  <Signature xmlns="http://www.w3.org/2000/09/xmldsig#">
+    <SignedInfo>
+      <CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+      <SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1"/>
+      <Reference URI="">
+        <Transforms>
+          <Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+        </Transforms>
+        <DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
+        <DigestValue><!--should not see this value-->/otGbaGvPsxvHXpaxzS5QXWvJRQ=</DigestValue>
+      </Reference>
+    </SignedInfo>
+    <SignatureValue>BOeWxdgnJw1hx2Vvwja947xDb8/5T+zFI1o8xw4aPH7lxxWVXk9s8UOYP99yjH1c+2iFNzm5VNaZG5op08bxZSHRsgU4DQ35jMO/D8Ra42zKRXHOd0TunjZ8WQhYV8RoESHKjsUGyjLhlavFMyUDMr+O4d3GSn+r5lBlw40zwyn7f7j+or8gyemp618vlTXrT31L9+xZaLRKgF8I0ZC4WpfJZGWOj7x4u/X1xfggf0jtDmbLrY8aMIXrH1cn46VnMqIrEwMC1zIJfPU+GeBQRDgcGhzq2ttaA2v3rGMzamk3qlqgMOEbI3kBWXSTuddPRkn5GVhQkb9nGa/0neAWzQ==</SignatureValue>
+    <KeyInfo>
+      <KeyName/>
+    </KeyInfo>
+  </Signature>
+  <Subject xmlns="urn:oasis:names:tc:SAML:2.0:assertion">
+    <NameID Format="urn:oasis:names:tc:SAML:2.0:nameid-format:transient">tstudent</NameID>
+    <SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+      <SubjectConfirmationData InResponseTo="_4" NotOnOrAfter="2014-03-12T21:40:05.392Z" Recipient="https://sp.example.com/assert"/>
+    </SubjectConfirmation>
+  </Subject>
+  <Conditions NotBefore="2014-03-12T21:35:05.387Z" NotOnOrAfter="2014-03-12T22:35:05.387Z">
+    <AudienceRestriction>
+      <Audience>https://sp.example.com/metadata.xml</Audience>
+    </AudienceRestriction>
+  </Conditions>
+  <AttributeStatement>
+    <Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname">
+      <AttributeValue>Test</AttributeValue>
+    </Attribute>
+    <Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress">
+      <AttributeValue>tstudent@example.com</AttributeValue>
+    </Attribute>
+    <Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/privatepersonalidentifier">
+      <AttributeValue>tstudent</AttributeValue>
+    </Attribute>
+    <Attribute Name="http://schemas.xmlsoap.org/claims/Group">
+      <AttributeValue>CN=Students,CN=Users,DC=idp,DC=example,DC=com</AttributeValue>
+    </Attribute>
+    <Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname">
+      <AttributeValue>Student</AttributeValue>
+    </Attribute>
+    <Attribute Name="http://schemas.xmlsoap.org/claims/CommonName">
+      <AttributeValue>Test Student</AttributeValue>
+    </Attribute>
+  </AttributeStatement>
+  <AuthnStatement AuthnInstant="2014-03-12T21:35:05.354Z" SessionIndex="_3" SessionNotOnOrAfter="2014-03-13T22:35:05.387Z">
+    <AuthnContext>
+      <AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</AuthnContextClassRef>
+    </AuthnContext>
+  </AuthnStatement>
+</Assertion>

--- a/test/saml2.coffee
+++ b/test/saml2.coffee
@@ -1296,7 +1296,7 @@ describe 'saml2', ->
       xml = sp.create_authn_request_xml(idp)
       dom = (new xmldom.DOMParser()).parseFromString xml
       method = dom.getElementsByTagName('SignatureMethod')[0]
-      assert.equal method.attributes[0].value, 'http://www.w3.org/2000/09/xmldsig#rsa-sha1'
+      assert.equal method.attributes[0].value, "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"
 
     it 'can create a signed AuthnRequest xml document with sha256 signature', () ->
       sp_options =

--- a/test/saml2.coffee
+++ b/test/saml2.coffee
@@ -198,6 +198,10 @@ describe 'saml2', ->
         result = saml2.check_saml_signature(get_test_file("good_response_twice_signed_dsig_ns_at_top.xml"), get_test_file("test.crt"))
         assert.notEqual null, result
 
+      it 'correctly ignores commented-out digest', ->
+        result = saml2.check_saml_signature(get_test_file("good_assertion_commented_out_digest.xml"), get_test_file("test.crt"))
+        assert.deepEqual result, [get_test_file("good_assertion_signed_data.xml")]
+
     describe 'check_status_success', =>
       it 'accepts a valid success status', =>
         assert saml2.check_status_success(@good_response_dom), "Did not get 'true' for valid response."


### PR DESCRIPTION
See: https://github.com/Clever/saml2/pull/287
This does two things:
- Upgrades to xml-crypto 6.1.2 which contains the latest security patches 
- Old get_signed_data used to manually recreate the signed data from each reference. This could be different than the actual data that was verified (which is exposed via the official getSignedReferences()).
We make sure to process only data from getSignedReferences()